### PR TITLE
Adding support for episode/series title, episode/season number, and more

### DIFF
--- a/python/lib/listitembuilder.py
+++ b/python/lib/listitembuilder.py
@@ -15,6 +15,8 @@ mediatype_map = {'episodeid': 'episode',
 
 def build_video_listitem(item):
     result = xbmcgui.ListItem(item.get('label'))
+    if 'title' in item:
+        result.setLabel(item['title'])
     if 'label2' in item:
         result.setLabel2(item['label2'])
 
@@ -27,6 +29,9 @@ def build_video_listitem(item):
         elif key in mediatype_map:
             infolabels['dbid'] = value
             infolabels['mediatype'] = mediatype_map[key]
+
+    if 'season' in item and 'episode' in item:
+        infolabels['season'], infolabels['episode'] = item['season'], item['episode']
 
     result.setInfo('video', infolabels)
 

--- a/python/lib/listitembuilder.py
+++ b/python/lib/listitembuilder.py
@@ -3,6 +3,7 @@ import xbmcgui
 
 
 infokey_map = {
+    'title': 'title',
     'season': 'season',
     'episode': 'episode',
     'playcount': 'playcount',
@@ -21,8 +22,6 @@ mediatype_map = {'episodeid': 'episode',
 
 def build_video_listitem(item):
     result = xbmcgui.ListItem(item.get('label'))
-    if 'title' in item:
-        result.setLabel(item['title'])
     if 'label2' in item:
         result.setLabel2(item['label2'])
 

--- a/python/lib/listitembuilder.py
+++ b/python/lib/listitembuilder.py
@@ -1,8 +1,12 @@
 import collections
 import xbmcgui
 
-# JSON keys that don't match info labels
+
 infokey_map = {
+    'season': 'season',
+    'episode': 'episode',
+    'playcount': 'playcount',
+    # JSON keys that don't match info labels
     'track': 'tracknumber',
     'runtime': 'duration',
     'showtitle': 'tvshowtitle',
@@ -29,9 +33,6 @@ def build_video_listitem(item):
         elif key in mediatype_map:
             infolabels['dbid'] = value
             infolabels['mediatype'] = mediatype_map[key]
-
-    if 'season' in item and 'episode' in item:
-        infolabels['season'], infolabels['episode'] = item['season'], item['episode']
 
     result.setInfo('video', infolabels)
 

--- a/python/lib/listitembuilder.py
+++ b/python/lib/listitembuilder.py
@@ -6,6 +6,8 @@ infokey_map = {
     'season': 'season',
     'episode': 'episode',
     'playcount': 'playcount',
+    'rating': 'rating',
+    'userrating': 'userrating',
     # JSON keys that don't match info labels
     'track': 'tracknumber',
     'runtime': 'duration',

--- a/python/lib/quickjson.py
+++ b/python/lib/quickjson.py
@@ -21,7 +21,7 @@ def get_random_episodes(tvshow_id=None, season=None, filters=None, limit=None):
         if season is not None:
             json_request['params']['season'] = season
     json_request['params']['sort'] = {'method': 'random'}
-    json_request['params']['properties'] = ['file']
+    json_request['params']['properties'] = ['file', 'title', 'season', 'episode', 'showtitle', 'playcount']
     if limit:
         json_request['params']['limits'] = {'end': limit}
 

--- a/python/lib/quickjson.py
+++ b/python/lib/quickjson.py
@@ -21,7 +21,7 @@ def get_random_episodes(tvshow_id=None, season=None, filters=None, limit=None):
         if season is not None:
             json_request['params']['season'] = season
     json_request['params']['sort'] = {'method': 'random'}
-    json_request['params']['properties'] = ['file', 'title', 'season', 'episode', 'showtitle', 'playcount']
+    json_request['params']['properties'] = ['file', 'title', 'season', 'episode', 'showtitle', 'playcount', 'rating', 'userrating']
     if limit:
         json_request['params']['limits'] = {'end': limit}
 


### PR DESCRIPTION
This PR will ensure the following attributes are included in new `ListItems` for episodes:
- Season Number
- Episode Number
- Series Title
- Episode Title
- Play count
- Rating
- User Rating

This ensures when looking at the playlist in a TV remote app such as Kore, the data will be more complete.
Similarly, other addons relying on episode information (such as Up Next) will benefit from this too. 