### PR TITLE
Feature: Control addition of recently watched videos

### DIFF
--- a/python/lib/playrandom.py
+++ b/python/lib/playrandom.py
@@ -4,11 +4,13 @@ from . import quickjson
 from .pykodi import get_main_addon, localize as L
 from .player import get_player
 from .generators import get_generator
+from datetime import datetime, timedelta
 
 SELECTWATCHMODE_HEADING = 32010
 WATCHMODE_ALLVIDEOS_TEXT = 16100
 WATCHMODE_UNWATCHED_TEXT = 16101
 WATCHMODE_WATCHED_TEXT = 16102
+WATCHMODE_WATCHEDBEFORE_TEXT = 32910
 WATCHMODE_ASKME_TEXT = 36521
 ADD_SOURCE_HEADER = 32011
 ADD_SOURCE_MESSAGE = 32012
@@ -16,14 +18,25 @@ ADD_SOURCE_MESSAGE = 32012
 WATCHMODE_ALLVIDEOS = 'all videos'
 WATCHMODE_UNWATCHED = 'unwatched'
 WATCHMODE_WATCHED = 'watched'
+WATCHMODE_WATCHEDBEFORE = 'watched before'
 WATCHMODE_ASKME = 'ask me'
 # Same order as settings
-WATCHMODES = (WATCHMODE_ALLVIDEOS, WATCHMODE_UNWATCHED, WATCHMODE_WATCHED, WATCHMODE_ASKME)
+WATCHMODES = (WATCHMODE_ALLVIDEOS, WATCHMODE_UNWATCHED, WATCHMODE_WATCHED, WATCHMODE_WATCHEDBEFORE, WATCHMODE_ASKME)
 WATCHMODE_NONE = 'none'
 
 unplayed_filter = {'field': 'playcount', 'operator': 'is', 'value': '0'}
 played_filter = {'field': 'playcount', 'operator': 'greaterthan', 'value': '0'}
 noextras_filter = {'field': 'season', 'operator': 'isnot', 'value': '0'}
+
+# Don't play video that has been watched in the past x months
+#if content == "tvshows":
+#    months = int(get_main_addon().getSetting('tvplayedmonths'))
+#if content == "movies":
+#    months = int(get_main_addon().getSetting('movieplayedmonths'))
+#
+#today = datetime.today()
+#playbefore = (today - timedelta(30*months)).strftime('%Y-%m-%d') 
+#lastwatched_filter = {'field': 'lastplayed', 'operator': 'lessthan', 'value': playbefore}
 
 def play(pathinfo):
     content, info = _parse_path(pathinfo)
@@ -124,6 +137,18 @@ def _parse_path(pathinfo):
         content = 'other'
         result['path'] = pathinfo['full path']
 
+
+    # Don't play video that has been watched in the past x months
+    if content == "tvshows":
+        months = int(get_main_addon().getSetting('tvplayedmonths'))
+    if content == "movies":
+        months = int(get_main_addon().getSetting('movieplayedmonths'))
+
+    today = datetime.today()
+    playbefore = (today - timedelta(30*months)).strftime('%Y-%m-%d') 
+    lastwatched_filter = {'field': 'lastplayed', 'operator': 'lessthan', 'value': playbefore}
+
+
     # DEPRECATED: forcewatchmode is deprecated in 1.1.0
     watchmode = _get_watchmode(pathinfo.get('watchmode') or pathinfo.get('forcewatchmode'), content)
     result['watchmode'] = watchmode
@@ -134,6 +159,8 @@ def _parse_path(pathinfo):
         filters.append(unplayed_filter)
     elif watchmode == WATCHMODE_WATCHED:
         filters.append(played_filter)
+    elif watchmode == WATCHMODE_WATCHEDBEFORE:
+        filters.append(lastwatched_filter)
 
     if content == 'tvshows' and get_main_addon().getSetting('exclude_extras') == 'true':
         filters.append(noextras_filter)
@@ -164,12 +191,14 @@ def _get_watchmode(pathwatchmode, content):
     watchmode = None
     if pathwatchmode:
         # skip 'all videos' from path, prefer add-on settings
-        if pathwatchmode.lower() in (WATCHMODE_UNWATCHED, WATCHMODE_WATCHED, WATCHMODE_ASKME):
+        if pathwatchmode.lower() in (WATCHMODE_UNWATCHED, WATCHMODE_WATCHED, WATCHMODE_WATCHEDBEFORE, WATCHMODE_ASKME):
             watchmode = pathwatchmode.lower()
         elif pathwatchmode == L(WATCHMODE_UNWATCHED_TEXT):
             watchmode = WATCHMODE_UNWATCHED
         elif pathwatchmode == L(WATCHMODE_WATCHED_TEXT):
             watchmode = WATCHMODE_WATCHED
+        elif pathwatchmode == L(WATCHMODE_WATCHEDBEFORE_TEXT):
+            watchmode == WATCHMODE_WATCHEDBEFORE
         elif pathwatchmode == L(WATCHMODE_ASKME_TEXT):
             watchmode = WATCHMODE_ASKME
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -10,7 +10,7 @@ msgid "Play one random"
 msgstr ""
 
 msgctxt "#32100"
-msgid "Play random :-)"
+msgid "Play random"
 msgstr ""
 
 msgctxt "#32101"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -10,7 +10,7 @@ msgid "Play one random"
 msgstr ""
 
 msgctxt "#32100"
-msgid "Play random"
+msgid "Play random :-)"
 msgstr ""
 
 msgctxt "#32101"
@@ -46,6 +46,14 @@ msgstr ""
 # Settings
 msgctxt "#32905"
 msgid "Hide busy notification before first video"
+msgstr ""
+
+msgctxt "#32909"
+msgid "Ignore videos played in the last x months"
+msgstr ""
+
+msgctxt "#32910"
+msgid "Not played recently"
 msgstr ""
 
 #  heading

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -70,11 +70,22 @@
 							<option label="16100">0</option>
 							<option label="16101">1</option>
 							<option label="16102">2</option>
-							<option label="36521">3</option>
+                                                        <option label="32910">3</option>
+							<option label="36521">4</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>
 				</setting>
+                                <setting id="movieplayedmonths" type="integer" label="32909" help="" parent="watchmodemovies">
+                                        <level>0</level>
+                                        <default>12</default>
+                                        <dependencies>
+                                                <dependency type="enable" setting="watchmodemovies">3</dependency>
+                                        </dependencies>
+                                        <control type="edit" format="integer">
+                                                <heading>32909</heading>
+                                        </control>
+                                </setting>
 				<setting id="watchmodetvshows" type="integer" label="32902" help="">
 					<level>0</level>
 					<default>0</default>
@@ -83,11 +94,22 @@
 							<option label="16100">0</option>
 							<option label="16101">1</option>
 							<option label="16102">2</option>
-							<option label="36521">3</option>
+                                                        <option label="32910">3</option>
+							<option label="36521">4</option>
 						</options>
 					</constraints>
 					<control type="spinner" format="string"/>
 				</setting>
+                                <setting id="tvplayedmonths" type="integer" label="32909" help="" parent="watchmodetvshows">
+                                        <level>0</level>
+                                        <default>6</default>
+                                        <dependencies>
+                                                <dependency type="enable" setting="watchmodetvshows">3</dependency>
+                                        </dependencies>
+                                        <control type="edit" format="integer">
+                                                <heading>32909</heading>
+                                        </control>
+                                </setting>
 				<setting id="watchmodemusicvideos" type="integer" label="32903" help="">
 					<level>0</level>
 					<default>0</default>


### PR DESCRIPTION
A purely "random" playlist will sometimes queue episodes that have been recently watched. This pull request adds the ability to filter out episodes/movies that have been played recently using Kodi's lastplayed filter. You can specify in the settings how many months back you want to avoid adding to the queue. I made it work for movies and tvshows, though it could be easily applied to any content. Thanks for the nice script!