### PR TITLE
Fix for Python 3.10

### DIFF
--- a/python/lib/listitembuilder.py
+++ b/python/lib/listitembuilder.py
@@ -1,4 +1,5 @@
 import collections
+from collections import abc
 import xbmcgui
 
 
@@ -27,7 +28,7 @@ def build_video_listitem(item):
 
     infolabels = {}
     for key, value in item.items():
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, abc.Mapping):
             continue
         if key in infokey_map:
             infolabels[infokey_map[key]] = value

--- a/python/lib/pykodi.py
+++ b/python/lib/pykodi.py
@@ -1,4 +1,5 @@
 import collections
+from collections import abc
 import json
 import xbmc
 import xbmcaddon
@@ -94,7 +95,7 @@ class LogJSONEncoder(json.JSONEncoder):
         super(LogJSONEncoder, self).__init__(*args, **kwargs)
 
     def default(self, obj):
-        if isinstance(obj, collections.Mapping):
+        if isinstance(obj, abc.Mapping):
             return dict((key, obj[key]) for key in obj.keys())
         if isinstance(obj, collections.Iterable):
             return list(obj)


### PR DESCRIPTION
Apparently accessing `collections.Mappable` directly was deprecated a while ago and Python 3.10, which is what I have in my Void Linux install finally removed support for this, breaking this plugin. Now `Mappable` is in `collections.abc`.

Deprecation warning is here on the docs: https://docs.python.org/3.9/library/collections.html and here's the removal: https://docs.python.org/3/whatsnew/3.10.html#:~:text=Remove%20deprecated%20aliases%20to%20Collections%20Abstract%20Base%20Classes%20from%20the%20collections%20module.%20(Contributed%20by%20Victor%20Stinner%20in%20bpo%2D37324.)

edit: I've written about 10 lines of Python in my entire life so feel free to suggest changes or whatever. This patch fixed the plugin on my system with 3.10, but yeah.